### PR TITLE
test and hide order token on peek

### DIFF
--- a/Global.-1.lua
+++ b/Global.-1.lua
@@ -51,15 +51,29 @@ function testAndHideOrderTokenOnPeek(object, player_color)
     if shouldHide then
       object.setHiddenFrom({player_color})
       broadcastToAll(msg, msgColor)
-      unhideColorMap[player_color] = Wait.frames(
-        function()
-          object.setHiddenFrom({})
-          unhideColorMap[player_color] = nil
-        end,
-        300
-      )  
+      addWaitToUnhideObject(object, player_color)
     end
   end
+end
+
+function addWaitToUnhideObject(object, player_color)
+  unhideColorMap[player_color] = Wait.frames(
+    function()
+      for _, player in ipairs(Player.getPlayers()) do
+        if player.color == player_color then
+          local hoverGuid = player.getHoverObject() and player.getHoverObject().guid
+          if hoverGuid == object.guid then
+            print(player_color..' still hovering')
+            addWaitToUnhideObject(object, player_color)
+            return
+          end
+        end
+      end
+      object.setHiddenFrom({})
+      unhideColorMap[player_color] = nil
+    end,
+    300
+  )
 end
 
 -- Scan for battle button function

--- a/Global.-1.lua
+++ b/Global.-1.lua
@@ -37,7 +37,8 @@ local unhideColorMap = {}
 function testAndHideOrderTokenOnPeek(object, player_color)
   local objectName = object.getName()
   local msg = player_color .. " peeked: " .. objectName
-  if unhideColorMap[player_color] then Wait.stop(unhideColorMap[player_color]) end
+  local waitId = player_color..object.guid
+  if unhideColorMap[waitId] then Wait.stop(unhideColorMap[waitId]) end
   if string.find(objectName, "order token") and not object.is_face_down then
     local msgColor = {1, 0, 0}
     local shouldHide = false
@@ -57,7 +58,8 @@ function testAndHideOrderTokenOnPeek(object, player_color)
 end
 
 function addWaitToUnhideObject(object, player_color)
-  unhideColorMap[player_color] = Wait.frames(
+  local waitId = player_color..object.guid
+  unhideColorMap[waitId] = Wait.frames(
     function()
       for _, player in ipairs(Player.getPlayers()) do
         if player.color == player_color then
@@ -70,7 +72,7 @@ function addWaitToUnhideObject(object, player_color)
         end
       end
       object.setHiddenFrom({})
-      unhideColorMap[player_color] = nil
+      unhideColorMap[waitId] = nil
     end,
     300
   )

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ForbiddenStarsMod
-Lua mod for Table Top Simulator
+Lua mod for Tabletop Simulator
 
-This mod is found in the Steam Workshop, for the game Table Top Simulator. This mod recreates the game Forbidden Stars by downloading assets from the game and is scripted using Lua!
+This mod is found in the Steam Workshop, for the game Tabletop Simulator. This mod recreates the game Forbidden Stars by downloading assets from the game and is scripted using Lua!
 You can find and subscribe to the mod here => https://steamcommunity.com/sharedfiles/filedetails/?id=2759334366
 
 Once you have subscribed to the mod, the Steam client should download the content automatically. You can play the mod by using the in-game menue in TTS.


### PR DESCRIPTION
Fixes #29 
I set this to broadcast All in the color of the offending player.

I figured out that if you hide an object on peek that it won't show what is underneath, it becomes a question mark.
I made a function to test if the order token is facing the correct way and if the peeking player does not own the order token then the token is hidden from the peeking player. That means the token still exists, but to the player it is just a question mark now. 

I used the Wait class to unhide the token after 300 frames, which is several seconds. This is longer than the cooldown for a peek and if the player peeks again then I stop the Wait and restart it.

Pain point with this is that if the player lingers over the token still peeking, even after the peek cooldown expires, a second peek event doesn't fire. The player would have to peek once more to trigger the second event and restart the unhide. I will look into how to fix this, perhaps through detecting a hover before unhiding.